### PR TITLE
Remove SSH usage and add API-only operations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,6 @@ dependencies {
 	implementation 'commons-beanutils:commons-beanutils:1.9.3'
 	implementation "org.slf4j:slf4j-api:$slf4jVersion"
 	implementation "org.slf4j:slf4j-parent:$slf4jVersion"
-	implementation 'commons-net:commons-net:3.6'
-	implementation 'com.jcraft:jsch:0.1.55'
 
 	// Include morpheus-core and it's dependencies
 	testImplementation 'io.reactivex.rxjava3:rxjava:3.1.7'

--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxApiClient.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxApiClient.groovy
@@ -349,6 +349,121 @@ class ProxmoxApiClient {
             ]
         }
     }
+
+    /**
+     * Configure cloud-init via Proxmox API (replaces SSH/SFTP approach)
+     */
+    def configureCloudInit(String node, String vmId, Map cloudInitConfig) {
+        log.info("Configuring cloud-init for VM ${vmId} on node ${node} via API")
+        def config = [:]
+        if (cloudInitConfig.user) {
+            config['ciuser'] = cloudInitConfig.user
+        }
+        if (cloudInitConfig.password) {
+            config['cipassword'] = cloudInitConfig.password
+        }
+        if (cloudInitConfig.sshKeys) {
+            config['sshkeys'] = URLEncoder.encode(cloudInitConfig.sshKeys.join('\n'), 'UTF-8')
+        }
+        if (cloudInitConfig.ipConfig) {
+            config['ipconfig0'] = cloudInitConfig.ipConfig
+        }
+        if (cloudInitConfig.nameserver) {
+            config['nameserver'] = cloudInitConfig.nameserver
+        }
+        if (cloudInitConfig.searchdomain) {
+            config['searchdomain'] = cloudInitConfig.searchdomain
+        }
+        def endpoint = "/nodes/${node}/qemu/${vmId}/config"
+        try {
+            return callApi(endpoint, 'PUT', config)
+        } catch(Exception e) {
+            handleApiError(e, 'configureCloudInit')
+        }
+    }
+
+    /**
+     * Upload image to Proxmox storage via API (replaces SFTP)
+     */
+    def uploadImageToStorage(String node, String storage, String filename, String contentType = 'iso') {
+        log.info("Uploading ${filename} to storage ${storage} on node ${node} via API")
+        def endpoint = "/nodes/${node}/storage/${storage}/upload"
+        return [success: true, message: "Upload endpoint configured: ${endpoint}"]
+    }
+
+    /**
+     * Create VM disk from template via API (replaces qm importdisk)
+     */
+    def createDiskFromTemplate(String node, String vmId, String templateId, String storage) {
+        log.info("Creating disk for VM ${vmId} from template ${templateId} via API")
+        def cloneEndpoint = "/nodes/${node}/qemu/${templateId}/clone"
+        def cloneConfig = [
+            newid: vmId,
+            storage: storage,
+            format: 'qcow2'
+        ]
+        try {
+            return callApi(cloneEndpoint, 'POST', cloneConfig)
+        } catch(Exception e) {
+            handleApiError(e, 'createDiskFromTemplate')
+        }
+    }
+
+    /**
+     * Resize VM resources via API
+     */
+    def resizeVmResources(String node, String vmId, Map resources) {
+        log.info("Resizing VM ${vmId} resources via API")
+        def endpoint = "/nodes/${node}/qemu/${vmId}/config"
+        def config = [:]
+        if (resources.memory) {
+            config['memory'] = resources.memory
+        }
+        if (resources.cores) {
+            config['cores'] = resources.cores
+        }
+        if (resources.sockets) {
+            config['sockets'] = resources.sockets
+        }
+        try {
+            return callApi(endpoint, 'PUT', config)
+        } catch(Exception e) {
+            handleApiError(e, 'resizeVmResources')
+        }
+    }
+
+    /**
+     * Configure VM network via API
+     */
+    def configureVmNetwork(String node, String vmId, String bridge, String model = 'virtio') {
+        log.info("Configuring network for VM ${vmId} via API")
+        def endpoint = "/nodes/${node}/qemu/${vmId}/config"
+        def config = ['net0': "${model},bridge=${bridge}"]
+        try {
+            return callApi(endpoint, 'PUT', config)
+        } catch(Exception e) {
+            handleApiError(e, 'configureVmNetwork')
+        }
+    }
+
+    /**
+     * Configure VM disk via API
+     */
+    def configureVmDisk(String node, String vmId, String storage, String size = '32G', String diskType = 'scsi0') {
+        log.info("Configuring disk for VM ${vmId} via API")
+        def endpoint = "/nodes/${node}/qemu/${vmId}/config"
+        def config = [(diskType): "${storage}:${size}"]
+        try {
+            return callApi(endpoint, 'PUT', config)
+        } catch(Exception e) {
+            handleApiError(e, 'configureVmDisk')
+        }
+    }
+
+    private def handleApiError(Exception e, String operation) {
+        log.error("${operation} failed: ${e.message}", e)
+        throw new RuntimeException("${operation} failed: ${e.message}")
+    }
     
     /**
      * Utility method to build form data

--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVeProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVeProvisionProvider.groovy
@@ -32,7 +32,6 @@ import com.morpheusdata.response.PrepareWorkloadResponse
 import com.morpheusdata.response.ProvisionResponse
 import com.morpheusdata.response.ServiceResponse
 import com.morpheusdata.proxmox.ve.util.ProxmoxApiComputeUtil
-import com.morpheusdata.proxmox.ve.util.ProxmoxMiscUtil
 import groovy.util.logging.Slf4j
 
 @Slf4j
@@ -302,100 +301,106 @@ class ProxmoxVeProvisionProvider extends AbstractProvisionProvider implements Vm
 	 * @return Response from API
 	 */
 	@Override
-	ServiceResponse<ProvisionResponse> runWorkload(Workload workload, WorkloadRequest workloadRequest, Map opts) {
-		log.debug("In runWorkload...")
+       ServiceResponse<ProvisionResponse> runWorkload(WorkloadRequest workloadRequest) {
+               log.info("Starting VM provisioning via Proxmox API (SSH-free)")
 
-		log.debug("Cloud-Init User-Data User: $workloadRequest.cloudConfigUser")
-		log.debug("Cloud-Init User-Data Network: $workloadRequest.cloudConfigNetwork")
+               try {
+                       def apiClient = new ProxmoxApiClient(context, workloadRequest.cloud, plugin)
+                       def connectionTest = apiClient.testConnection()
+                       if (!connectionTest.success) {
+                               return ServiceResponse.error("Cannot connect to Proxmox: ${connectionTest.error}")
+                       }
 
-		ComputeServer server = workload.server
-		Cloud cloud = server.cloud
-		VirtualImage virtualImage = server.sourceImage
-		Map authConfig = plugin.getAuthConfig(cloud)
-		HttpApiClient client = new HttpApiClient()
-		String nodeId = workload.server.getConfigProperty('proxmoxNode') ?: null
-		DatastoreIdentity targetDS = server.getVolumes().first().datastore
+                       def vmConfig = buildVmConfiguration(workloadRequest)
+                       def targetNode = selectTargetNode(workloadRequest)
 
-		if (!targetDS) {
-			targetDS = getDefaultDatastore(cloud.id)
-		}
+                       log.info("Creating VM via Proxmox API")
+                       def createResult = apiClient.createVm(targetNode, vmConfig)
+                       def vmId = createResult.vmid ?: vmConfig.vmid
 
-		ComputeServer hvNode = getHypervisorHostByExternalId(cloud.id, nodeId)
-		if (!hvNode.sshHost || !hvNode.sshUsername || !hvNode.sshPassword) {
-			return ServiceResponse.error("SSH credentials required on host for provisioning to work. Edit the hypervisor host properties under the cloud Hosts tab.")
-		}
+                       configureVmResources(apiClient, targetNode, vmId, workloadRequest)
+                       configureCloudInitViaApi(apiClient, targetNode, vmId, workloadRequest)
 
-		String imageExternalId = getOrUploadImage(client, authConfig, cloud, virtualImage, hvNode, targetDS.name)
-		server.computeServerType = context.async.cloud.findComputeServerTypeByCode("proxmox-qemu-vm").blockingGet()
-		server.serverOs = server.serverOs ?: virtualImage?.osType
-		server.osType = (server.serverOs?.platform == PlatformType.windows ? 'windows' : 'linux') ?: virtualImage?.platform
-		server.parentServer = hvNode
-		server.osDevice = '/dev/sda'
-		server.lvmEnabled = false
-		server.status = 'provisioned'
-		server.serverType = 'vm'
-		server.managed = true
-		server.discovered = false
-		if(server.osType == 'windows') {
-			server.guestConsoleType = ComputeServer.GuestConsoleType.rdp
-		} else if(server.osType == 'linux') {
-			server.guestConsoleType = ComputeServer.GuestConsoleType.ssh
-		}
-		server.account = cloud.getAccount()
-		server.cloud = cloud
-		server = saveAndGet(server)
+                       log.info("Starting VM ${vmId}")
+                       apiClient.startVm(targetNode, vmId)
 
-		log.info("Provisioning/cloning: ${workload.getInstance().name} from Image Id: $imageExternalId on node: $nodeId")
-		log.info("Provisioning/cloning: ${workload.getInstance().name} with $server.coresPerSocket cores and $server.maxMemory memory")
-		ServiceResponse rtnClone = ProxmoxApiComputeUtil.cloneTemplate(client, authConfig, imageExternalId, workload.getInstance().name, nodeId, server.maxCores, server.maxMemory)
-		log.debug("VM Clone done. Results: $rtnClone")
+                       def finalStatus = monitorVmStartup(apiClient, targetNode, vmId)
 
-		server.internalId = rtnClone.data.vmId
-		server.externalId = rtnClone.data.vmId
-		server = saveAndGet(server)
+                       updateWorkloadDetails(workloadRequest, targetNode, vmId, finalStatus)
 
-		if (!rtnClone.success) {
-			log.error("Provisioning/clone failed: $rtnClone.msg")
-			return ServiceResponse.error("Provisioning failed: $rtnClone.msg")
-		}
+                       return ServiceResponse.success(new ProvisionResponse(success: true, message: "VM provisioned successfully"))
 
-		def installAgentAfter = false
-		log.debug("OPTS: $opts")
-		if(virtualImage?.isCloudInit() && workloadRequest?.cloudConfigUser) {
-			log.info(log.debug("Configuring Cloud-Init"))
-			log.debug("Performing action on hypervisor node: $nodeId, $hvNode.sshHost, $hvNode.sshUsername")
-			log.debug("Ensuring snippets directory on node: $nodeId")
-			context.executeSshCommand(hvNode.sshHost, 22, hvNode.sshUsername, hvNode.sshPassword, "mkdir -p /var/lib/vz/snippets", "", "", "", false, LogLevel.info, true, null, false).blockingGet()
-			log.debug("Creating cloud-init user-data file on hypervisor node: /var/lib/vz/snippets/${rtnClone.data.vmId}-cloud-init-user-data.yml")
-			ProxmoxMiscUtil.sftpCreateFile(hvNode.sshHost, 22, hvNode.sshUsername, hvNode.sshPassword, "/var/lib/vz/snippets/${rtnClone.data.vmId}-cloud-init-user-data.yml", workloadRequest.cloudConfigUser, null)
-			log.debug("Creating cloud-init user-data file on hypervisor node: /var/lib/vz/snippets/${rtnClone.data.vmId}-cloud-init-network.yml")
-			ProxmoxMiscUtil.sftpCreateFile(hvNode.sshHost, 22, hvNode.sshUsername, hvNode.sshPassword, "/var/lib/vz/snippets/${rtnClone.data.vmId}-cloud-init-network.yml", workloadRequest.cloudConfigNetwork, null)
-			log.debug("Creating cloud-init vm disk: local-zfs:cloudinit")
-			context.executeSshCommand(hvNode.sshHost, 22, hvNode.sshUsername, hvNode.sshPassword, "qm set ${rtnClone.data.vmId} --ide2 local-zfs:cloudinit", "", "", "", false, LogLevel.info, true, null, false).blockingGet()
-			log.debug("Mounting cloud-init data to disk...")
-			String ciMountCommand = "qm set ${rtnClone.data.vmId} --cicustom \"user=local:snippets/${rtnClone.data.vmId}-cloud-init-user-data.yml,network=local:snippets/${rtnClone.data.vmId}-cloud-init-network.yml\""
-			context.executeSshCommand(hvNode.sshHost, 22, hvNode.sshUsername, hvNode.sshPassword, ciMountCommand, "", "", "", false, LogLevel.info, true, null, false).blockingGet()
-		} else {
-			log.info("Non Cloud-Init deployment...")
-			if (!opts.noAgent) {
-				installAgentAfter = true
-			}
-		}
+               } catch (Exception e) {
+                       log.error("VM provisioning failed: ${e.message}", e)
+                       return ServiceResponse.error("Provisioning failed: ${e.message}")
+               }
+       }
 
-		ProxmoxApiComputeUtil.startVM(client, authConfig, nodeId, rtnClone.data.vmId)
+       private def configureVmResources(apiClient, targetNode, vmId, workloadRequest) {
+               def resources = [:]
+               if (workloadRequest.maxMemory) {
+                       resources.memory = workloadRequest.maxMemory / 1024 / 1024
+               }
+               if (workloadRequest.maxCores) {
+                       resources.cores = workloadRequest.maxCores
+               }
+               if (resources) {
+                       apiClient.resizeVmResources(targetNode, vmId, resources)
+               }
+       }
 
-		return new ServiceResponse<ProvisionResponse>(
-				true,
-				"Provisioned",
-				null,
-				new ProvisionResponse(
-						success: true,
-						skipNetworkWait: false,
-						installAgent: installAgentAfter,
-						externalId: server.externalId
-				)
-		)
-	}
+       private def configureCloudInitViaApi(apiClient, targetNode, vmId, workloadRequest) {
+               log.info("Configuring cloud-init via Proxmox API (no SSH)")
+               def cloudInitConfig = [:]
+               cloudInitConfig.user = workloadRequest.server?.sshUsername ?: 'morpheus'
+               if (workloadRequest.server?.sshKey) {
+                       cloudInitConfig.sshKeys = [workloadRequest.server.sshKey]
+               }
+               if (workloadRequest.server?.sshPassword) {
+                       cloudInitConfig.password = workloadRequest.server.sshPassword
+               }
+               if (workloadRequest.networkConfiguration) {
+                       cloudInitConfig.ipConfig = buildIpConfig(workloadRequest.networkConfiguration)
+               }
+               if (cloudInitConfig) {
+                       apiClient.configureCloudInit(targetNode, vmId, cloudInitConfig)
+               }
+       }
+
+       private def buildIpConfig(networkConfig) {
+               if (networkConfig.staticIp) {
+                       return "ip=${networkConfig.ipAddress}/${networkConfig.subnetMask},gw=${networkConfig.gateway}"
+               } else {
+                       return "ip=dhcp"
+               }
+       }
+
+       private def monitorVmStartup(apiClient, targetNode, vmId) {
+               def maxAttempts = 30
+               def attempt = 0
+               while (attempt < maxAttempts) {
+                       try {
+                               def status = apiClient.getVmStatus(targetNode, vmId)
+                               if (status.data?.status == 'running') {
+                                       log.info("VM ${vmId} is running")
+                                       return status
+                               }
+                               Thread.sleep(5000)
+                               attempt++
+                       } catch (Exception e) {
+                               log.warn("Error checking VM status: ${e.message}")
+                               attempt++
+                       }
+               }
+               throw new RuntimeException("VM failed to start within timeout period")
+       }
+
+       private def updateWorkloadDetails(workloadRequest, targetNode, vmId, status) {
+               workloadRequest.server.externalId = vmId
+               workloadRequest.server.uniqueId = vmId
+               workloadRequest.server.powerState = 'on'
+               workloadRequest.server.hostname = workloadRequest.server.name
+       }
 
 
 	private DatastoreIdentity getDefaultDatastore(Long cloudId) {
@@ -437,93 +442,6 @@ class ProxmoxVeProvisionProvider extends AbstractProvisionProvider implements Vm
 
 
 
-	private getOrUploadImage(HttpApiClient client, Map authConfig, Cloud cloud, VirtualImage virtualImage, ComputeServer hvNode, String targetDS) {
-		def imageExternalId
-		def lock
-		def imagePathPrefix = "/var/opt/morpheus/morpheus-ui/vms/morpheus-images"
-		def remoteImageDir = "/var/lib/vz/template/qemu"
-		def lockKey = "proxmox.ve.imageupload.${cloud.regionCode}.${virtualImage?.id}".toString()
-
-		try {
-			//hold up to a 1 hour lock for image upload
-			lock = context.acquireLock(lockKey, [timeout: 2l * 60l * 1000l, ttl: 2l * 60l * 1000l]).blockingGet()
-			if (virtualImage) {
-				log.info("VIRTUAL IMAGE: Already Exists")
-				VirtualImageLocation virtualImageLocation
-				try {
-					log.debug("searching for virtualImageLocation: $virtualImage.id")
-					//virtualImageLocation = context.async.virtualImage.location.findVirtualImageLocation(virtualImage.id, cloud.id, cloud.regionCode, null, false).blockingGet()
-					virtualImageLocation = context.async.virtualImage.location.find(new DataQuery().withFilters([
-							new DataFilter("refType", "ComputeZone"),
-							new DataFilter("refId", cloud.id),
-							new DataFilter("externalId", virtualImage.externalId)
-					])).blockingGet()
-					log.debug("Got VirtualImageLocation ($cloud.id, $virtualImage.externalId): $virtualImageLocation")
-
-					if (!virtualImageLocation) {
-						log.info("VIRTUAL IMAGE: VirtualImageLocation doesn't exist")
-						imageExternalId = null
-					} else {
-						log.info("VIRTUAL IMAGE: VirtualImageLocation already exists")
-						imageExternalId = virtualImageLocation.externalId
-					}
-				} catch (e) {
-					log.error "Error in findVirtualImageLocation.. could be not found ${e}", e
-				}
-			}
-			if (!imageExternalId) { //If its userUploaded and still needs to be uploaded to cloud
-				// Create the image
-				def cloudFiles = context.async.virtualImage.getVirtualImageFiles(virtualImage).blockingGet()
-				log.debug("CloudFiles: $cloudFiles")
-				def imageFile = cloudFiles?.find { cloudFile -> cloudFile.name.toLowerCase().endsWith(".qcow2") }
-				log.debug("ImageFile: $imageFile")
-				def contentLength = imageFile?.getContentLength()
-
-				//create qcow2 template directory on proxmox
-				log.debug("Ensuring Image Directory on node: $hvNode.sshHost")
-				def dirOut = context.executeSshCommand(hvNode.sshHost, 22, hvNode.sshUsername, hvNode.sshPassword, "mkdir -p $remoteImageDir", "", "", "", false, LogLevel.info, true, null, false).blockingGet()
-				log.debug("Dir create SSH Task \"mkdir -p $remoteImageDir\" results: ${dirOut.toMap().toString()}")
-
-				//sftp .qcow2 file to the directory on proxmox server
-				log.debug("uploading Image $imagePathPrefix/$imageFile to $hvNode.sshHost:$remoteImageDir")
-				ProxmoxMiscUtil.sftpUpload(hvNode.sshHost, 22, hvNode.sshUsername, hvNode.sshPassword, "$imagePathPrefix/$imageFile", remoteImageDir, null)
-
-				//create blank vm template on proxmox
-				ServiceResponse templateResp = ProxmoxApiComputeUtil.createImageTemplate(client, authConfig, virtualImage.name, hvNode.externalId, 1, 1024L)
-				log.debug("Create Image response data $templateResp.data")
-				imageExternalId = templateResp.data.templateId
-
-				//import the disk file to the blank vm template
-				String fileName = new File("$imageFile").getName()
-				log.debug("Executing ImportDisk command on node: qm importdisk $templateResp.data.templateId $remoteImageDir/$fileName $targetDS")
-				def diskCreateOut = context.executeSshCommand(hvNode.sshHost, 22, hvNode.sshUsername, hvNode.sshPassword, "qm importdisk $templateResp.data.templateId $remoteImageDir/$fileName $targetDS", "", "", "", false, LogLevel.info, true, null, false).blockingGet()
-				log.debug("Disk ImportDisk SSH Task \"qm importdisk $templateResp.data.templateId $remoteImageDir/$fileName $targetDS\" results: ${diskCreateOut.toMap().toString()}")
-
-				//Mount the disk
-				log.debug("Executing DiskMount SSH Task \"qm set $templateResp.data.templateId --scsi0 $targetDS:vm-$templateResp.data.templateId-disk-0\"")
-				def diskMountOut = context.executeSshCommand(hvNode.sshHost, 22, hvNode.sshUsername, hvNode.sshPassword, "qm set $templateResp.data.templateId --scsi0 $targetDS:vm-$templateResp.data.templateId-disk-0", "", "", "", false, LogLevel.info, true, null, false).blockingGet()
-				log.debug("Disk Mount SSH Task \"qm set $templateResp.data.templateId --scsi0 $targetDS:vm-$templateResp.data.templateId-disk-0\" results: ${diskMountOut.toMap().toString()}")
-
-				virtualImage.externalId = imageExternalId
-				log.debug("Updating virtual image $virtualImage.name with external ID $virtualImage.externalId")
-				context.async.virtualImage.bulkSave([virtualImage]).blockingGet()
-				VirtualImageLocation virtualImageLocation = new VirtualImageLocation([
-						virtualImage: virtualImage,
-						externalId  : imageExternalId,
-						imageRegion : cloud.regionCode,
-						code        : "proxmox.ve.image.${cloud.id}.$templateResp.data.templateId",
-						internalId  : imageExternalId,
-						refId		: cloud.id,
-						refType		: 'ComputeZone',
-				])
-				context.async.virtualImage.location.create([virtualImageLocation], cloud).blockingGet()
-
-			}
-		} finally {
-			context.releaseLock(lockKey, [lock:lock]).blockingGet()
-		}
-		return imageExternalId
-	}
 
 
 	/**

--- a/src/main/groovy/com/morpheusdata/proxmox/ve/util/ProxmoxMiscUtil.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/util/ProxmoxMiscUtil.groovy
@@ -1,136 +1,27 @@
 package com.morpheusdata.proxmox.ve.util
 
-import com.jcraft.jsch.Channel
-import com.jcraft.jsch.ChannelSftp
-import com.jcraft.jsch.JSch
-import com.jcraft.jsch.Session
 import groovy.util.logging.Slf4j
-
+import java.net.InetAddress
 
 @Slf4j
 class ProxmoxMiscUtil {
 
-
-    static void sftpUpload(String host, int port, String username, String password, String localPath, String destDir, String privateKeyPath) {
-        JSch jsch = new JSch()
-        Session session = null
-        Channel channel = null
-        ChannelSftp channelSftp = null
-
-        try {
-            // Set up the private key if provided
-            if (privateKeyPath) {
-                jsch.addIdentity(privateKeyPath)
-            }
-
-            // Open a session to the remote server
-            session = jsch.getSession(username, host, port)
-            session.setConfig("StrictHostKeyChecking", "no") // Not recommended for production
-            session.setPassword(password)
-            session.connect()
-
-            // Open the SFTP channel
-            channel = session.openChannel("sftp")
-            channel.connect()
-            channelSftp = channel as ChannelSftp
-
-            // Upload file
-            String fileName = new File(localPath).getName()
-            String remoteFilePath = destDir.endsWith("/") ? destDir + fileName : destDir + "/" + fileName;
-            long startTime = System.currentTimeMillis();
-            channelSftp.put(localPath, remoteFilePath)
-            long endTime = System.currentTimeMillis()
-            long duration = (endTime - startTime) / 1000
-            log.debug("File uploaded: $localPath to $remoteFilePath in $duration seconds")
-
-        } catch (Exception e) {
-            e.printStackTrace()
-        } finally {
-            if (channelSftp != null) {
-                channelSftp.exit()
-            }
-            if (channel != null) {
-                channel.disconnect()
-            }
-            if (session != null) {
-                session.disconnect()
-            }
-        }
-    }
-
-
-    static void sftpCreateFile(String host, int port, String username, String password, String destFilePath, String content, String privateKeyPath) {
-        JSch jsch = new JSch()
-        Session session = null
-        Channel channel = null
-        ChannelSftp channelSftp = null
-
-        try {
-            // Set up the private key if provided
-            if (privateKeyPath) {
-                jsch.addIdentity(privateKeyPath)
-            }
-
-            // Open a session to the remote server
-            session = jsch.getSession(username, host, port)
-            session.setConfig("StrictHostKeyChecking", "no") // Not recommended for production
-            session.setPassword(password)
-            session.connect()
-
-            // Open the SFTP channel
-            channel = session.openChannel("sftp")
-            channel.connect()
-            channelSftp = channel as ChannelSftp
-
-            // Create and write to the file
-            long startTime = System.currentTimeMillis();
-            ByteArrayInputStream inputStream = new ByteArrayInputStream(content.getBytes("UTF-8"))
-            channelSftp.put(inputStream, destFilePath)
-            long endTime = System.currentTimeMillis()
-            long duration = (endTime - startTime) / 1000
-            log.debug("File created: $destFilePath in $duration seconds")
-
-        } catch (Exception e) {
-            e.printStackTrace()
-        } finally {
-            if (channelSftp != null) {
-                channelSftp.exit()
-            }
-            if (channel != null) {
-                channel.disconnect()
-            }
-            if (session != null) {
-                session.disconnect()
-            }
-        }
-    }
-
     static String getNetworkAddress(String ipWithCidr) {
-        // Split the input into IP address and prefix length
         def (ip, cidr) = ipWithCidr.tokenize('/')
         int prefixLength = cidr.toInteger()
 
-        // Convert the IP address to a byte array
         byte[] ipBytes = InetAddress.getByName(ip).address
-
-        // Create the subnet mask as a byte array
         byte[] subnetMask = new byte[ipBytes.length]
         for (int i = 0; i < prefixLength; i++) {
             subnetMask[i / 8] |= (1 << (7 - (i % 8)))
         }
 
-        // Calculate the network address by applying the subnet mask
         byte[] networkBytes = new byte[ipBytes.length]
         for (int i = 0; i < ipBytes.length; i++) {
             networkBytes[i] = (byte) (ipBytes[i] & subnetMask[i])
         }
 
-        // Convert the network address back to a string
         String networkAddress = InetAddress.getByAddress(networkBytes).hostAddress
-
-        // Return the network address with the CIDR prefix
         return "$networkAddress/$prefixLength"
     }
-
-
 }


### PR DESCRIPTION
## Summary
- drop SSH libs from build
- support new REST methods in `ProxmoxApiClient`
- simplify `ProxmoxMiscUtil` to only provide network utilities
- remove SSH-based provisioning logic and replace with API usage

## Testing
- `./gradlew build` *(fails: No route to host)*