### PR TITLE
Fix icon references

### DIFF
--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxBackupProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxBackupProvider.groovy
@@ -46,7 +46,7 @@ class ProxmoxBackupProvider extends AbstractBackupProvider {
 
     @Override
     Icon getIcon() {
-        return new Icon(path: 'proxmox.svg', darkPath: 'proxmox-dark.svg')
+        return new Icon(path: 'proxmox-full-lockup-color.svg', darkPath: 'proxmox-full-lockup-inverted-color.svg')
     }
 
     @Override


### PR DESCRIPTION
## Summary
- update backup provider icon paths to existing images

## Testing
- `./gradlew test` *(fails: No route to host)*